### PR TITLE
javadoc error fixes for release candidate

### DIFF
--- a/api/src/main/java/org/eclipse/microprofile/context/ManagedExecutor.java
+++ b/api/src/main/java/org/eclipse/microprofile/context/ManagedExecutor.java
@@ -68,8 +68,8 @@ import org.eclipse.microprofile.context.spi.ContextManagerProvider;
  * then the action runs with the already-captured context.
  * </li>
  * <li>
- * Otherwise, each type of thread context is either {@link #propagated} from the thread
- * that creates the completion stage or marked to be {@link #cleared}, according to the
+ * Otherwise, each type of thread context is either {@link Builder#propagated propagated} from the thread
+ * that creates the completion stage or marked to be {@link Builder#cleared cleared}, according to the
  * configuration of the managed executor that is the default asynchronous execution facility
  * for the new stage and its parent stage. In the case that a managed executor is supplied
  * as the <code>executor</code> argument to a <code>*Async</code> method, the supplied
@@ -269,8 +269,9 @@ public interface ManagedExecutor extends ExecutorService {
      * that is returned by this method and all dependent stages that are created from it,
      * and all dependent stages that are created from those, and so forth.</p>
      *
-     * @param <U> result type of the completion stage.
-     * @return the new completion stage.
+     * @param value result with which the completable future is completed.
+     * @param <U> result type of the completable future.
+     * @return the new completable future.
      */
     <U> CompletableFuture<U> completedFuture(U value);
 
@@ -281,6 +282,7 @@ public interface ManagedExecutor extends ExecutorService {
      * that is returned by this method and all dependent stages that are created from it,
      * and all dependent stages that are created from those, and so forth.</p>
      *
+     * @param value result with which the completable future is completed.
      * @param <U> result type of the completion stage.
      * @return the new completion stage.
      */
@@ -293,8 +295,9 @@ public interface ManagedExecutor extends ExecutorService {
      * that is returned by this method and all dependent stages that are created from it,
      * and all dependent stages that are created from those, and so forth.</p>
      *
-     * @param <U> result type of the completion stage.
-     * @return the new completion stage.
+     * @param ex exception or error with which the completable future is completed.
+     * @param <U> result type of the completable future.
+     * @return the new completable future.
      */
     <U> CompletableFuture<U> failedFuture(Throwable ex);
 
@@ -305,6 +308,7 @@ public interface ManagedExecutor extends ExecutorService {
      * that is returned by this method and all dependent stages that are created from it,
      * and all dependent stages that are created from those, and so forth.</p>
      *
+     * @param ex exception or error with which the stage is completed.
      * @param <U> result type of the completion stage.
      * @return the new completion stage.
      */

--- a/api/src/main/java/org/eclipse/microprofile/context/ThreadContext.java
+++ b/api/src/main/java/org/eclipse/microprofile/context/ThreadContext.java
@@ -252,21 +252,21 @@ public interface ThreadContext {
      * access to the scope of the session, request, and so forth that created the
      * contextualized action.
      * 
-     * For example, consider the following <code>&#64;RequestScoped<code> resource:
+     * For example, consider the following <code>&#64;RequestScoped</code> resource:
      * 
-     * <code><pre>
+     * <pre><code>
     &#64;RequestScoped
     public class MyRequestScopedBean {
         public String getState() {
           // returns some request-specific information to the caller
         }
     }
-    </pre></code>
+    </code></pre>
      * 
      * CDI context propagation includes request, session and conversation contexts.
      * When CDI context is propagated, all of the above mentioned contexts that are
      * currently active will be available to the contextualized task with preserved 
-     * state. <code><pre>
+     * state. <pre><code>
     ManagedExecutor exec = ManagedExecutor.builder()
         .propagated(ThreadContext.CDI, ThreadContext.APPLICATION)
         .build();
@@ -276,14 +276,14 @@ public interface ThreadContext {
     
     &#64;GET
     public void foo() {
-        exec.supplyAsync(() -> {
+        exec.supplyAsync(() -&gt; {
             String state = reqBean.getState();
             // do some work with the request state
-        }).thenApply(more -> {
+        }).thenApply(more -&gt; {
             // request state also available in future stages
         });
     }
-    </pre></code>
+    </code></pre>
      *
      * If CDI context is 'cleared', currently active contexts will still be
      * available to the contextualized task, but their state will be erased.
@@ -348,8 +348,8 @@ public interface ThreadContext {
      * <code>Executor contextSnapshot = threadContext.currentContextExecutor();
      * ...
      * // from another thread, or after thread context has changed,
-     * contextSnapshot.execute(() -> obj.doSomethingThatNeedsContext());
-     * contextSnapshot.execute(() -> doSomethingElseThatNeedsContext(x, y));
+     * contextSnapshot.execute(() -&gt; obj.doSomethingThatNeedsContext());
+     * contextSnapshot.execute(() -&gt; doSomethingElseThatNeedsContext(x, y));
      * </code></pre>
      *
      * <p>The returned <code>Executor</code> must raise <code>IllegalArgumentException</code>
@@ -500,6 +500,7 @@ public interface ThreadContext {
      * completable future or any dependent stages created from it, other than the new dependent
      * completable future that is created by this method.</p>
      *
+     * @param <T> completable future result type.
      * @param stage a completable future whose completion triggers completion of the new completable
      *        future that is created by this method.
      * @return the new completable future.
@@ -527,6 +528,7 @@ public interface ThreadContext {
      * stage or any dependent stages created from it, other than the new dependent
      * completion stage that is created by this method.</p>
      *
+     * @param <T> completion stage result type.
      * @param stage a completion stage whose completion triggers completion of the new stage
      *        that is created by this method.
      * @return the new completion stage.

--- a/api/src/main/java/org/eclipse/microprofile/context/spi/ContextManager.java
+++ b/api/src/main/java/org/eclipse/microprofile/context/spi/ContextManager.java
@@ -58,7 +58,7 @@ public interface ContextManager {
         public Builder withThreadContextProviders(ThreadContextProvider... providers);
 
         /**
-         * Load all discoverable {@link ContextManagerExtension} instances via the {@link ServiceLoader}
+         * Load all discoverable {@link ContextManagerExtension} instances via the {@link java.util.ServiceLoader}
          * mechanism on the current thread-context {@link ClassLoader} (unless overridden by {@link #forClassLoader(ClassLoader)}).
          * 
          * @return this builder
@@ -73,7 +73,7 @@ public interface ContextManager {
         public Builder withContextManagerExtensions(ContextManagerExtension... extensions);
 
         /**
-         * Load all discoverable {@link ThreadContextProvider} instances via the {@link ServiceLoader}
+         * Load all discoverable {@link ThreadContextProvider} instances via the {@link java.util.ServiceLoader}
          * mechanism on the current thread-context {@link ClassLoader} (unless overridden by {@link #forClassLoader(ClassLoader)}).
          * 
          * @return this builder

--- a/api/src/main/java/org/eclipse/microprofile/context/spi/ContextManagerProvider.java
+++ b/api/src/main/java/org/eclipse/microprofile/context/spi/ContextManagerProvider.java
@@ -90,6 +90,7 @@ public interface ContextManagerProvider {
      *
      * @param provider the provider implementation to register.
      * @throws IllegalStateException if an implementation is already registered.
+     * @return registration instance that gives the caller control over unregistering.
      */
     public static ContextManagerProviderRegistration register(ContextManagerProvider provider) throws IllegalStateException {
         if (INSTANCE.compareAndSet(null, provider)) {
@@ -137,7 +138,7 @@ public interface ContextManagerProvider {
      * @see ContextManager.Builder#build()
      * @see #registerContextManager(ContextManager, ClassLoader)
      */
-    public ContextManager getContextManager(ClassLoader classLoader);
+    public ContextManager getContextManager(ClassLoader classloader);
 
     /**
      * Returns a new {@link ContextManager.Builder} to create new {@link ContextManager}

--- a/api/src/main/java/org/eclipse/microprofile/context/spi/ThreadContextProvider.java
+++ b/api/src/main/java/org/eclipse/microprofile/context/spi/ThreadContextProvider.java
@@ -22,7 +22,7 @@ import java.util.Map;
 
 /**
  * <p>Third party providers of thread context implement this interface to enable the
- * provided type of context to participate in thread context capture & propagation
+ * provided type of context to participate in thread context capture and propagation
  * when the <code>ManagedExecutor</code>
  * and <code>ThreadContext</code> are used to create and contextualize dependent
  * actions and tasks.</p>
@@ -45,7 +45,7 @@ import java.util.Map;
  * <p><code>ManagedExecutor</code> and <code>ThreadContext</code> must use the
  * <code>ServiceLoader</code> to identify all available implementations of
  * <code>ThreadContextProvider</code> that can participate in thread context capture
- * & propagation and must invoke them either to capture current thread context or establish
+ * and propagation and must invoke them either to capture current thread context or establish
  * default thread context per the configuration of the <code>ManagedExecutor</code> or
  * <code>ThreadContext</code> instance wherever these interfaces are used to create
  * and contextualize dependent actions and tasks.</p>
@@ -110,7 +110,7 @@ public interface ThreadContextProvider {
      *
      * <p>The application can use the values documented for the various thread context
      * types when configuring a <code>ManagedExecutor</code> or <code>ThreadContext</code>
-     * to capture & propagate only specific types of thread context.</p>
+     * to capture and propagate only specific types of thread context.</p>
      *
      * <p>For example:</p>
      * <pre><code>

--- a/tck/src/main/java/org/eclipse/microprofile/context/tck/MPConfigTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/context/tck/MPConfigTest.java
@@ -114,6 +114,10 @@ public class MPConfigTest extends Arquillian {
     /**
      * Verify that the cleared and propagated attributes of a ManagedExecutor are defaulted
      * according to the defaults specified by the application in MicroProfile Config.
+     *
+     * @throws ExecutionException indicates test failure
+     * @throws InterruptedException indicates test failure
+     * @throws TimeoutException indicates test failure
      */
     @Test
     public void defaultContextPropagationForManagedExecutorViaMPConfig()
@@ -207,6 +211,10 @@ public class MPConfigTest extends Arquillian {
     /**
      * Verify that the maxAsync and maxQueued attributes of a ManagedExecutor are defaulted
      * according to the defaults specified by the application in MicroProfile Config.
+     *
+     * @throws ExecutionException indicates test failure
+     * @throws InterruptedException indicates test failure
+     * @throws TimeoutException indicates test failure
      */
     @Test(dependsOnMethods = "beanInjected")
     public void defaultMaxAsyncAndMaxQueuedForManagedExecutorViaMPConfig()
@@ -270,6 +278,10 @@ public class MPConfigTest extends Arquillian {
     /**
      * Verify that MicroProfile config defaults the cleared attribute when only the
      * propagated and maxQueued attributes are specified by the application.
+     *
+     * @throws ExecutionException indicates test failure
+     * @throws InterruptedException indicates test failure
+     * @throws TimeoutException indicates test failure
      */
     @Test(dependsOnMethods = "beanInjected")
     public void explicitlySpecifiedPropagatedTakesPrecedenceOverDefaults()
@@ -352,6 +364,10 @@ public class MPConfigTest extends Arquillian {
     /**
      * Verify that MicroProfile config defaults the maxAsync attribute and honors the explicitly specified
      * maxQueued attribute, when only the propagated and maxQueued attributes are specified by the application.
+     *
+     * @throws ExecutionException indicates test failure
+     * @throws InterruptedException indicates test failure
+     * @throws TimeoutException indicates test failure
      */
     @Test(dependsOnMethods = "beanInjected")
     public void explicitlySpecifyMaxQueued5()

--- a/tck/src/main/java/org/eclipse/microprofile/context/tck/ManagedExecutorTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/context/tck/ManagedExecutorTest.java
@@ -134,9 +134,10 @@ public class ManagedExecutorTest extends Arquillian {
     /**
      * Verify that the ManagedExecutor implementation clears context
      * types that are not configured under propagated, or cleared.
-     * @throws TimeoutException 
-     * @throws ExecutionException 
-     * @throws InterruptedException 
+     *
+     * @throws TimeoutException indicates test failure
+     * @throws ExecutionException indicates test failure
+     * @throws InterruptedException indicates test failure
      */
     @Test
     public void clearUnspecifiedContexts() throws InterruptedException, ExecutionException, TimeoutException {
@@ -181,6 +182,10 @@ public class ManagedExecutorTest extends Arquillian {
      * by the ManagedExecutor's completedFuture implementation. Thread context is captured
      * at each point where a dependent stage is added, rather than solely upon creation of the
      * initial stage or construction of the builder.
+     *
+     * @throws ExecutionException indicates test failure
+     * @throws InterruptedException indicates test failure
+     * @throws TimeoutException indicates test failure
      */
     @Test
     public void completedFutureDependentStagesRunWithContext() throws ExecutionException, InterruptedException, TimeoutException {
@@ -284,6 +289,8 @@ public class ManagedExecutorTest extends Arquillian {
      * by the ManagedExecutor's completedStage implementation. Thread context is captured
      * at each point where a dependent stage is added, rather than solely upon creation of the
      * initial stage or construction of the builder.
+     *
+     * @throws InterruptedException indicates test failure
      */
     @Test
     public void completedStageDependentStagesRunWithContext() throws InterruptedException {
@@ -367,6 +374,10 @@ public class ManagedExecutorTest extends Arquillian {
     /**
      * Verify the MicroProfile Context Propagation implementation of propagate(), and cleared()
      * for ManagedExecutor.Builder.
+     *
+     * @throws ExecutionException indicates test failure
+     * @throws InterruptedException indicates test failure
+     * @throws TimeoutException indicates test failure
      */
     @Test
     public void contextControlsForManagedExecutorBuilder() throws InterruptedException, ExecutionException, TimeoutException {
@@ -443,6 +454,10 @@ public class ManagedExecutorTest extends Arquillian {
      * When an already-contextualized Callable is specified as the action/task,
      * the action/task runs with its already-captured context rather than
      * capturing and applying context per the configuration of the managed executor.
+     *
+     * @throws ExecutionException indicates test failure
+     * @throws InterruptedException indicates test failure
+     * @throws TimeoutException indicates test failure
      */
     @Test
     public void contextOfContextualCallableOverridesContextOfManagedExecutor() throws ExecutionException, InterruptedException, TimeoutException {
@@ -526,6 +541,10 @@ public class ManagedExecutorTest extends Arquillian {
      * When an already-contextualized Consumer or BiFunction is specified as the action/task,
      * the action/task runs with its already-captured context rather than
      * capturing and applying context per the configuration of the managed executor.
+     *
+     * @throws ExecutionException indicates test failure
+     * @throws InterruptedException indicates test failure
+     * @throws TimeoutException indicates test failure
      */
     @Test
     public void contextOfContextualConsumerAndBiFunctionOverrideContextOfManagedExecutor()
@@ -616,6 +635,10 @@ public class ManagedExecutorTest extends Arquillian {
      * When an already-contextualized Function is specified as the action/task,
      * the action/task runs with its already-captured context rather than
      * capturing and applying context per the configuration of the managed executor.
+     *
+     * @throws ExecutionException indicates test failure
+     * @throws InterruptedException indicates test failure
+     * @throws TimeoutException indicates test failure
      */
     @Test
     public void contextOfContextualFunctionOverridesContextOfManagedExecutor() throws ExecutionException, InterruptedException, TimeoutException {
@@ -714,6 +737,10 @@ public class ManagedExecutorTest extends Arquillian {
      * When an already-contextualized Runnable is specified as the action/task,
      * the action/task runs with its already-captured context rather than
      * capturing and applying context per the configuration of the managed executor.
+     *
+     * @throws ExecutionException indicates test failure
+     * @throws InterruptedException indicates test failure
+     * @throws TimeoutException indicates test failure
      */
     @Test
     public void contextOfContextualRunnableOverridesContextOfManagedExecutor() throws ExecutionException, InterruptedException, TimeoutException {
@@ -792,6 +819,10 @@ public class ManagedExecutorTest extends Arquillian {
      * When an already-contextualized Supplier or BiFunction is specified as the action/task,
      * the action/task runs with its already-captured context rather than
      * capturing and applying context per the configuration of the managed executor.
+     *
+     * @throws ExecutionException indicates test failure
+     * @throws InterruptedException indicates test failure
+     * @throws TimeoutException indicates test failure
      */
     @Test
     public void contextOfContextualSuppplierAndBiConsumerOverrideContextOfManagedExecutor()
@@ -877,6 +908,10 @@ public class ManagedExecutorTest extends Arquillian {
      * Verify that thread context is cleared per the configuration of the ManagedExecutor builder
      * for all tasks that are executed via the execute method. This test supplies the ManagedExecutor
      * to a Java SE CompletableFuture, which invokes the execute method to run tasks asynchronously.
+     *
+     * @throws ExecutionException indicates test failure
+     * @throws InterruptedException indicates test failure
+     * @throws TimeoutException indicates test failure
      */
     @Test
     public void executedTaskRunsWithClearedContext() throws ExecutionException, InterruptedException, TimeoutException {
@@ -921,6 +956,10 @@ public class ManagedExecutorTest extends Arquillian {
     /**
      * Verify that thread context is propagated per the configuration of the ManagedExecutor builder
      * for all tasks that are executed via the execute method.
+     *
+     * @throws ExecutionException indicates test failure
+     * @throws InterruptedException indicates test failure
+     * @throws TimeoutException indicates test failure
      */
     @Test
     public void executedTaskRunsWithContext() throws ExecutionException, InterruptedException, TimeoutException {
@@ -973,6 +1012,10 @@ public class ManagedExecutorTest extends Arquillian {
      * by the ManagedExecutor's failedFuture implementation. Thread context is captured
      * at each point where a dependent stage is added, rather than solely upon creation of the
      * initial stage or construction of the builder.
+     * 
+     * @throws ExecutionException indicates test failure
+     * @throws InterruptedException indicates test failure
+     * @throws TimeoutException indicates test failure
      */
     @Test
     public void failedFutureDependentStagesRunWithContext() throws ExecutionException, InterruptedException, TimeoutException {
@@ -1083,6 +1126,10 @@ public class ManagedExecutorTest extends Arquillian {
      * by the ManagedExecutor's failedStage implementation. Thread context is captured
      * at each point where a dependent stage is added, rather than solely upon creation of the
      * initial stage or construction of the builder.
+     *
+     * @throws ExecutionException indicates test failure
+     * @throws InterruptedException indicates test failure
+     * @throws TimeoutException indicates test failure
      */
     @Test
     public void failedStageDependentStagesRunWithContext() throws ExecutionException, InterruptedException, TimeoutException {
@@ -1160,6 +1207,10 @@ public class ManagedExecutorTest extends Arquillian {
     /**
      * Verify that the ManagedExecutor implementation starts 2 async tasks/actions, and no more,
      * when maxAsync is configured to 2.
+     *
+     * @throws ExecutionException indicates test failure
+     * @throws InterruptedException indicates test failure
+     * @throws TimeoutException indicates test failure
      */
     @Test
     public void maxAsync2() throws ExecutionException, InterruptedException, TimeoutException {
@@ -1217,6 +1268,10 @@ public class ManagedExecutorTest extends Arquillian {
      * Attempt to specify invalid values (less than -1 and 0) for maxAsync.
      * Require this to be rejected upon the maxQueued operation per JavaDoc
      * rather than from the build method.
+     *
+     * @throws ExecutionException indicates test failure
+     * @throws InterruptedException indicates test failure
+     * @throws TimeoutException indicates test failure
      */
     @Test
     public void maxAsyncInvalidValues() throws ExecutionException, InterruptedException, TimeoutException {
@@ -1263,6 +1318,10 @@ public class ManagedExecutorTest extends Arquillian {
 
     /**
      * Verify that 3 tasks/actions, and no more, can be queued when maxQueued is configured to 3.
+     *
+     * @throws ExecutionException indicates test failure
+     * @throws InterruptedException indicates test failure
+     * @throws TimeoutException indicates test failure
      */
     @Test
     public void maxQueued3() throws ExecutionException, InterruptedException, TimeoutException {
@@ -1338,6 +1397,10 @@ public class ManagedExecutorTest extends Arquillian {
      * Attempt to specify invalid values (less than -1 and 0) for maxQueued.
      * Require this to be rejected upon the maxQueued operation per JavaDoc
      * rather than from the build method.
+     *
+     * @throws ExecutionException indicates test failure
+     * @throws InterruptedException indicates test failure
+     * @throws TimeoutException indicates test failure
      */
     @Test
     public void maxQueuedInvalidValues() throws ExecutionException, InterruptedException, TimeoutException {
@@ -1380,6 +1443,9 @@ public class ManagedExecutorTest extends Arquillian {
      * by the ManagedExecutor's newIncompleteFuture implementation. Thread context is captured
      * at each point where a dependent stage is added, rather than solely upon creation of the
      * initial stage or construction of the builder.
+     *
+     * @throws ExecutionException indicates test failure
+     * @throws InterruptedException indicates test failure
      */
     @Test
     public void newIncompleteFutureDependentStagesRunWithContext() throws ExecutionException, InterruptedException {
@@ -1473,6 +1539,10 @@ public class ManagedExecutorTest extends Arquillian {
 
     /**
      * Verify that Application context makes the application's thread context class loader available to the task.
+     *
+     * @throws ExecutionException indicates test failure
+     * @throws InterruptedException indicates test failure
+     * @throws TimeoutException indicates test failure
      */
     @Test
     public void propagateApplicationContext() throws ExecutionException, InterruptedException, TimeoutException {
@@ -1515,6 +1585,8 @@ public class ManagedExecutorTest extends Arquillian {
      * runs with a transaction on the thread. It would be nice to test participation in the same
      * transaction, but that isn't possible without the TCK having a dependency on a particular
      * type of transactional resource.
+     *
+     * @throws Exception indicates test failure
      */
     @Test
     public void propagateTransactionContextJTA() throws Exception {
@@ -1647,6 +1719,10 @@ public class ManagedExecutorTest extends Arquillian {
      * Verify that the ManagedExecutor shutdownNow method prevents additional tasks from being submitted
      * and cancels tasks that are currently in progress or queued.
      * Also verify that once the tasks and actions terminate, the ManagedExecutor transitions to terminated state.
+     *
+     * @throws ExecutionException indicates test failure
+     * @throws InterruptedException indicates test failure
+     * @throws TimeoutException indicates test failure
      */
     @Test
     public void shutdownNowPreventsAdditionalSubmitsAndCancelsTasks() throws ExecutionException, InterruptedException, TimeoutException {
@@ -1797,6 +1873,10 @@ public class ManagedExecutorTest extends Arquillian {
      * Verify that the ManagedExecutor shutdown method prevents additional tasks from being submitted
      * but does not interfere with tasks and actions that are running or queued.
      * Also verify that once the tasks and actions finish, the ManagedExecutor transitions to terminated state.
+     *
+     * @throws ExecutionException indicates test failure
+     * @throws InterruptedException indicates test failure
+     * @throws TimeoutException indicates test failure
      */
     @Test
     public void shutdownPreventsAdditionalSubmits() throws ExecutionException, InterruptedException, TimeoutException {
@@ -1910,6 +1990,10 @@ public class ManagedExecutorTest extends Arquillian {
     /**
      * Verify that the ManagedExecutor.Builder can be used to create multiple ManagedExecutors with 
      * different configured contexts.
+     *
+     * @throws ExecutionException indicates test failure
+     * @throws InterruptedException indicates test failure
+     * @throws TimeoutException indicates test failure
      */
     @Test
     public void reuseManagedExecutorBuilder() throws ExecutionException, InterruptedException, TimeoutException {
@@ -1964,6 +2048,9 @@ public class ManagedExecutorTest extends Arquillian {
      * by the ManagedExecutor's runAsync implementation. Thread context is captured
      * at each point where a dependent stage is added, rather than solely upon creation of the
      * initial stage or construction of the builder.
+     *
+     * @throws ExecutionException indicates test failure
+     * @throws InterruptedException indicates test failure
      */
     @Test
     public void runAsyncStageAndDependentStagesRunWithContext() throws ExecutionException, InterruptedException {
@@ -2107,6 +2194,10 @@ public class ManagedExecutorTest extends Arquillian {
      * Verify that thread context is captured and propagated per the configuration of the
      * ManagedExecutor builder for all tasks that are submitted via the submit(Callable),
      * submit(Runnable) and submit(Runnable, result) methods.
+     *
+     * @throws ExecutionException indicates test failure
+     * @throws InterruptedException indicates test failure
+     * @throws TimeoutException indicates test failure
      */
     @Test
     public void submittedTasksRunWithContext() throws ExecutionException, InterruptedException, TimeoutException {
@@ -2201,6 +2292,10 @@ public class ManagedExecutorTest extends Arquillian {
      * by the ManagedExecutor's supplyAsync implementation. Thread context is captured
      * at each point where a dependent stage is added, rather than solely upon creation of the
      * initial stage or construction of the builder.
+     *
+     * @throws ExecutionException indicates test failure
+     * @throws InterruptedException indicates test failure
+     * @throws TimeoutException indicates test failure
      */
     @Test
     public void supplyAsyncStageAndDependentStagesRunWithContext() throws ExecutionException, InterruptedException, TimeoutException {
@@ -2313,6 +2408,10 @@ public class ManagedExecutorTest extends Arquillian {
      * ManagedExecutor builder for all tasks that are submitted via the ManagedExecutor's
      * timed invokeAll operation. Thread context is captured at the point where invokeAll is
      * invoked, rather than upon creation of the executor or construction of the builder.
+     *
+     * @throws ExecutionException indicates test failure
+     * @throws InterruptedException indicates test failure
+     * @throws TimeoutException indicates test failure
      */
     @Test
     public void timedInvokeAllRunsTasksWithContext()
@@ -2383,6 +2482,10 @@ public class ManagedExecutorTest extends Arquillian {
      * ManagedExecutor builder for one or more tasks that are submitted via the ManagedExecutor's
      * timed invokeAny operation. Thread context is captured at the point where invokeAny is
      * invoked, rather than upon creation of the executor or construction of the builder.
+     *
+     * @throws ExecutionException indicates test failure
+     * @throws InterruptedException indicates test failure
+     * @throws TimeoutException indicates test failure
      */
     @Test
     public void timedInvokeAnyRunsTaskWithContext()
@@ -2443,6 +2546,10 @@ public class ManagedExecutorTest extends Arquillian {
      * ManagedExecutor builder for all tasks that are submitted via the ManagedExecutor's
      * untimed invokeAll operation. Thread context is captured at the point where invokeAll is
      * invoked, rather than upon creation of the executor or construction of the builder.
+     *
+     * @throws ExecutionException indicates test failure
+     * @throws InterruptedException indicates test failure
+     * @throws TimeoutException indicates test failure
      */
     @Test
     public void untimedInvokeAllRunsTasksWithContext()
@@ -2582,6 +2689,10 @@ public class ManagedExecutorTest extends Arquillian {
      * ManagedExecutor builder for one or more tasks that are submitted via the ManagedExecutor's
      * untimed invokeAny operation. Thread context is captured at the point where invokeAny is
      * invoked, rather than upon creation of the executor or construction of the builder.
+     *
+     * @throws ExecutionException indicates test failure
+     * @throws InterruptedException indicates test failure
+     * @throws TimeoutException indicates test failure
      */
     @Test
     public void untimedInvokeAnyRunsTasksWithContext()

--- a/tck/src/main/java/org/eclipse/microprofile/context/tck/ThreadContextTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/context/tck/ThreadContextTest.java
@@ -127,6 +127,8 @@ public class ThreadContextTest extends Arquillian {
      * Verify that if JTA transactions are supported, then configuring cleared=TRANSACTION
      * results in the active transaction being suspended before running a task and resumed afterward,
      * such that a task can use its own transactions if so desired.
+     *
+     * @throws Exception indicates test failure
      */
     @Test
     public void clearTransactionContextJTA() throws Exception {
@@ -205,7 +207,8 @@ public class ThreadContextTest extends Arquillian {
     /**
      * Verify that the ThreadContext implementation clears context
      * types that are not configured under propagated, unchanged, or cleared.
-     * @throws Exception 
+     *
+     * @throws Exception indicates test failure 
      */
     @Test
     public void clearUnspecifiedContexts() throws Exception {
@@ -262,6 +265,8 @@ public class ThreadContextTest extends Arquillian {
      * current thread per the configuration of the ThreadContext builder, and that the context is
      * applied when the BiConsumer accept method runs. This test case aligns with use case of
      * supplying a contextual BiConsumer to a completion stage that is otherwise not context-aware.
+     *
+     * @throws InterruptedException indicates test failure
      */
     @Test
     public void contextualBiConsumerRunsWithContext() throws InterruptedException {
@@ -326,6 +331,10 @@ public class ThreadContextTest extends Arquillian {
      * current thread per the configuration of the ThreadContext builder, and that the context is
      * applied when the BiFunction apply method runs. This test case aligns with use case of
      * supplying a contextual BiFunction to a completion stage that is otherwise not context-aware.
+     *
+     * @throws ExecutionException indicates test failure
+     * @throws InterruptedException indicates test failure
+     * @throws TimeoutException indicates test failure
      */
     @Test
     public void contextualBiFunctionRunsWithContext()
@@ -388,6 +397,10 @@ public class ThreadContextTest extends Arquillian {
      * current thread per the configuration of the ThreadContext builder, and that the context is
      * applied when the Callable call method runs. This test case aligns with use case of
      * supplying a contextual Callable to an unmanaged executor that is otherwise not context-aware.
+     *
+     * @throws ExecutionException indicates test failure
+     * @throws InterruptedException indicates test failure
+     * @throws TimeoutException indicates test failure
      */
     @Test
     public void contextualCallableRunsWithContext()
@@ -433,6 +446,8 @@ public class ThreadContextTest extends Arquillian {
      * current thread per the configuration of the ThreadContext builder, and that the context is
      * applied when the Consumer accept method runs. This test case aligns with use case of
      * supplying a contextual Consumer to a completion stage that is otherwise not context-aware.
+     *
+     * @throws InterruptedException indicates test failure
      */
     @Test
     public void contextualConsumerRunsWithContext() throws InterruptedException {
@@ -497,6 +512,10 @@ public class ThreadContextTest extends Arquillian {
      * current thread per the configuration of the ThreadContext builder, and that the context is
      * applied when the Function apply method runs. This test case aligns with use case of
      * supplying a contextual Function to a completion stage that is otherwise not context-aware.
+     *
+     * @throws ExecutionException indicates test failure
+     * @throws InterruptedException indicates test failure
+     * @throws TimeoutException indicates test failure
      */
     @Test
     public void contextualFunctionRunsWithContext()
@@ -559,6 +578,10 @@ public class ThreadContextTest extends Arquillian {
      * current thread per the configuration of the ThreadContext builder, and that the context is
      * applied when the Runnable run method runs. This test case aligns with use case of
      * supplying a contextual Runnable to a completion stage that is otherwise not context-aware.
+     *
+     * @throws ExecutionException indicates test failure
+     * @throws InterruptedException indicates test failure
+     * @throws TimeoutException indicates test failure
      */
     @Test
     public void contextualRunnableRunsWithContext()
@@ -627,6 +650,8 @@ public class ThreadContextTest extends Arquillian {
      * current thread per the configuration of the ThreadContext builder, and that the context is
      * applied when the Supplier get method runs. This test case aligns with use case of
      * supplying a contextual Supplier to a completion stage that is otherwise not context-aware.
+     *
+     * @throws InterruptedException indicates test failure
      */
     @Test
     public void contextualSupplierRunsWithContext() throws InterruptedException {
@@ -683,7 +708,8 @@ public class ThreadContextTest extends Arquillian {
     /**
      * Verify that the ThreadContext.Builder can be used to create multiple ThreadContexts with 
      * different configured contexts.
-     * @throws Exception 
+     *
+     * @throws Exception indicates test failure
      */
     @Test
     public void reuseThreadContextBuilder() throws Exception {
@@ -795,7 +821,7 @@ public class ThreadContextTest extends Arquillian {
     /**
      * Verify that the MicroProfile Context Propagation implementation finds third-party thread context providers
      * that are made available to the ServiceLoader, allows their configuration via the ThreadContext builder,
-     * and correctly captures & propagates or clears these thread context types per the builder configuration.
+     * and correctly captures and propagates or clears these thread context types per the builder configuration.
      * Subsequently verify that the MicroProfile Context Propagation implementation properly restores thread context
      * after the contextual action completes.
      */
@@ -858,6 +884,10 @@ public class ThreadContextTest extends Arquillian {
      * method can be used to create a dependent CompletableFuture instance that completes when the
      * original stage completes and runs dependent stage actions with context that is captured
      * from the thread that creates the dependent stage.
+     *
+     * @throws ExecutionException indicates test failure
+     * @throws InterruptedException indicates test failure
+     * @throws TimeoutException indicates test failure
      */
     @Test
     public void withContextCaptureDependentCompletableFuturesRunWithContext()
@@ -964,6 +994,10 @@ public class ThreadContextTest extends Arquillian {
      * method can be used to create a dependent CompletionStage instance that completes when the
      * original stage completes and runs dependent stage actions with context that is captured
      * from the thread that creates the dependent stage.
+     *
+     * @throws ExecutionException indicates test failure
+     * @throws InterruptedException indicates test failure
+     * @throws TimeoutException indicates test failure
      */
     @Test
     public void withContextCaptureDependentCompletionStagesRunWithContext() throws ExecutionException, InterruptedException, TimeoutException {
@@ -1072,6 +1106,9 @@ public class ThreadContextTest extends Arquillian {
     /**
      * Verify that dependent stages created via withContextCapture can be completed independently
      * of the original stage.
+     *
+     * @throws ExecutionException indicates test failure
+     * @throws InterruptedException indicates test failure
      */
     @Test
     public void withContextCaptureDependentStageForcedCompletion() throws ExecutionException, InterruptedException {
@@ -1104,6 +1141,10 @@ public class ThreadContextTest extends Arquillian {
      * The withContextCapture method should be able to create multiple dependent stages
      * having a single parent stage, where each of the dependent stages propagates a
      * different set of thread context.
+     *
+     * @throws ExecutionException indicates test failure
+     * @throws InterruptedException indicates test failure
+     * @throws TimeoutException indicates test failure
      */
     @Test
     public void withContextCaptureMultipleThreadContexts()
@@ -1157,6 +1198,10 @@ public class ThreadContextTest extends Arquillian {
      * The withContextCapture method should be able to create a dependent stage that is
      * associated with a thread context even if its parent stage is already associated with
      * a different thread context. Both stages must honor their respective thread context.
+     *
+     * @throws ExecutionException indicates test failure
+     * @throws InterruptedException indicates test failure
+     * @throws TimeoutException indicates test failure
      */
     @Test
     public void withContextCaptureSwitchThreadContext()
@@ -1209,6 +1254,10 @@ public class ThreadContextTest extends Arquillian {
     /**
      * Verify the MicroProfile Context Propagation implementation of propagate(), cleared(), and unchanged()
      * for ThreadContext.Builder.
+     *
+     * @throws ExecutionException indicates test failure
+     * @throws InterruptedException indicates test failure
+     * @throws TimeoutException indicates test failure
      */
     @Test
     public void contextControlsForThreadContextBuilder() throws InterruptedException, ExecutionException, TimeoutException {
@@ -1298,6 +1347,10 @@ public class ThreadContextTest extends Arquillian {
      * current thread per the configuration of the ThreadContext builder, and that the context is
      * applied to the thread where the Executor's execute method runs. This test case aligns with use 
      * case of supplying a contextual Executor to a thread that is otherwise not context-aware.
+     *
+     * @throws ExecutionException indicates test failure
+     * @throws InterruptedException indicates test failure
+     * @throws TimeoutException indicates test failure
      */
     @Test
     public void currentContextExecutorRunsWithContext() throws InterruptedException, ExecutionException, TimeoutException {

--- a/tck/src/main/java/org/eclipse/microprofile/context/tck/cdi/CDIBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/context/tck/cdi/CDIBean.java
@@ -116,6 +116,8 @@ public class CDIBean {
 
     /**
      * Verify that injected ME instances are useable in a very basic way
+     *
+     * @throws Exception indicates test failure
      */
     public void testBasicExecutorUsable() throws Exception {
         assertEquals(appProduced.supplyAsync(() -> "hello").get(MAX_WAIT_SEC, TimeUnit.SECONDS), "hello");

--- a/tck/src/main/java/org/eclipse/microprofile/context/tck/cdi/CDIContextTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/context/tck/cdi/CDIContextTest.java
@@ -81,6 +81,8 @@ public class CDIContextTest extends Arquillian {
     /**
      * Set some state on Request, Session, and Conversation scoped beans and verify
      * the state is propagated to the thread where the other task runs.
+     *
+     * @throws Exception indicates test failure
      */
     @Test
     public void testCDIMECtxPropagate() throws Exception {
@@ -100,6 +102,8 @@ public class CDIContextTest extends Arquillian {
     /**
      * Set some state on Request, Session, and Conversation scoped beans and verify
      * the state is cleared on the thread where the other task runs.
+     *
+     * @throws Exception indicates test failure
      */
     @Test
     public void testCDIMECtxClear() throws Exception {
@@ -129,6 +133,8 @@ public class CDIContextTest extends Arquillian {
     /**
      * Set some state on a request scoped bean, then verify a contextualized callable
      * has the state propagated to it when ran on the same thread.
+     *
+     * @throws Exception indicates test failure
      */
     @Test
     public void testCDITCCtxPropagate() throws Exception {
@@ -149,6 +155,8 @@ public class CDIContextTest extends Arquillian {
     /**
      * Set some state on a request scoped bean, then verify a contextualized callable
      * has the state cleared from it when ran on the same thread.
+     *
+     * @throws Exception indicates test failure
      */
     @Test
     public void testCDITCCtxClear() throws Exception {

--- a/tck/src/main/java/org/eclipse/microprofile/context/tck/contexts/label/Label.java
+++ b/tck/src/main/java/org/eclipse/microprofile/context/tck/contexts/label/Label.java
@@ -32,6 +32,7 @@ public class Label {
 
     /**
      * Get the current 'label' context.
+     * @return current label.
      */
     public static String get() {
         return context.get();
@@ -39,6 +40,7 @@ public class Label {
 
     /**
      * Set the current 'label' context.
+     * @param label new label.
      */
     public static void set(String label) {
         context.set(label == null ? "" : label);


### PR DESCRIPTION
When attempting to build a release candidate driver, additional build processing ran, which included building JavaDocs and identified a large number of JavaDoc errors, the first of which are documented under a comment to #141

After fixing these and running locally, further JavaDoc errors appeared, which are fixed under this pull as well.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>