### PR TITLE
enable asciidoc compilation and fix errors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -138,6 +138,7 @@
     <modules>
         <module>api</module>
         <module>tck</module>
+        <module>spec</module>
     </modules>
 
     <pluginRepositories>

--- a/spec/src/main/asciidoc/cdi.asciidoc
+++ b/spec/src/main/asciidoc/cdi.asciidoc
@@ -19,7 +19,7 @@
 
 In order to use `ManagedExecutor` and `ThreadContext` as CDI beans, define producer for them as `@ApplicationScoped` so that instances are shared and reused. In most cases, more granular and shorter-lived scopes are undesirable. For instance, having a new `ManagedExecutor` instance created per HTTP request typically does not make sense. In the event that a more granular scope is desired, the application must take care to supply a disposer to ensure that the executor is shut down once it is no longer needed. When using application scope, it is optional to supply a disposer because the specification requires the container to automatically shut down `ManagedExecutor` instances when the application stops.
 
-==== Example Producer for `ManagedExecutor`
+=== Example Producer for `ManagedExecutor`
 
 Example qualifier,
 [source, java]
@@ -72,7 +72,7 @@ public class MySecondBean {
 }
 ----
 
-==== Example Producer for `ThreadContext`
+=== Example Producer for `ThreadContext`
 
 Example qualifier,
 [source, java]


### PR DESCRIPTION
When running the release candidate build, it failed because asciidoc was not being compiled. When I updated the pom to include it, I saw 2 failures, so I'm fixing those as well under this pull.