### PR TITLE
Remove extraneous <url> tag from the TCK's pom.xml.

### DIFF
--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -20,7 +20,6 @@
     </parent>
     <artifactId>microprofile-context-propagation-tck</artifactId>
     <name>microprofile-context-propagation-tck</name>
-    <url>http://maven.apache.org</url>
     <properties>
         <arquillian.version>1.4.0.Final</arquillian.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>


### PR DESCRIPTION
Removing an extraneous <url> tag from the TCK's pom.xml that was causing maven.apache.org to show up as the HomePage for the project on maven central.

Signed-off-by: Nathan Mittlestat <nmittles@us.ibm.com>