### PR TITLE
CDIContextTest should allow for inactive contexts, split the tests.

### DIFF
--- a/mp_checkstyle_rules.xml
+++ b/mp_checkstyle_rules.xml
@@ -69,9 +69,6 @@
         <module name="LeftCurly">
             <property name="option" value="EOL"/>
         </module>
-        <module name="RightCurly">
-            <property name="option" value="ALONE"/>
-        </module>
         <module name="EmptyStatement"/>
         <module name="EqualsHashCode"/>
         <module name="DefaultComesLast"/>

--- a/tck/src/main/java/org/eclipse/microprofile/context/tck/cdi/ConversationScopedBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/context/tck/cdi/ConversationScopedBean.java
@@ -23,7 +23,7 @@ import java.io.Serializable;
 import javax.enterprise.context.ConversationScoped;
 
 @ConversationScoped
-public class ConversationScopeBean extends AbstractBean implements Serializable {
+public class ConversationScopedBean extends AbstractBean implements Serializable {
 
     private static final long serialVersionUID = 8175924512735191234L;
 


### PR DESCRIPTION
Fixes #170 

I split the test and replaced any direct injection with dynamic resolution to avoid trying to inject beans from inactive contexts. Every test now checks if context is active and should it get negative answer, it successfully ends.

As for the change in `mp_checkstyle_rules.xml` - I am fine reverting that if you ask for it, but if you wouldn't mind removing it, I think it's a bit overzealous rule. This is probably the sole project where I am seeing this right curly limitations and checkstyle is giving me hell every time :)