### PR TITLE
Remove circular bean dependency in tests.

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/context/tck/MPConfigBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/context/tck/MPConfigBean.java
@@ -26,8 +26,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
 import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Disposes;
-import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.inject.Qualifier;
@@ -48,27 +46,6 @@ public class MPConfigBean {
     @Retention(RetentionPolicy.RUNTIME)
     @Target({ ElementType.FIELD, ElementType.METHOD, ElementType.PARAMETER })
     public @interface Max5Queue {}
-
-    @Produces @ApplicationScoped @Max5Queue
-    protected ManagedExecutor createExecutor() {
-        // rely on MP Config for defaults of maxAsync=1, cleared=Remaining
-        return ManagedExecutor.builder()
-                              .maxQueued(5)
-                              .propagated()
-                              .build();
-    }
-
-    public void shutdown(@Disposes @Max5Queue ManagedExecutor executor) {
-        executor.shutdown();
-    }
-
-    // None of the defaults from MP Config apply because the application explicitly specifies all values
-    @Produces @ApplicationScoped @Named("producedThreadContext")
-    protected ThreadContext bufferContext = ThreadContext.builder()
-                            .propagated(Buffer.CONTEXT_NAME)
-                            .unchanged()
-                            .cleared(ThreadContext.ALL_REMAINING)
-                            .build();
 
     @Inject
     protected void setCompletedFuture(@Max5Queue ManagedExecutor executor) {

--- a/tck/src/main/java/org/eclipse/microprofile/context/tck/MPConfigTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/context/tck/MPConfigTest.java
@@ -98,6 +98,7 @@ public class MPConfigTest extends Arquillian {
         return ShrinkWrap.create(WebArchive.class, MPConfigTest.class.getSimpleName() + ".war")
                 .addClass(MPConfigBean.class)
                 .addClass(MPConfigTest.class)
+                .addClass(ProducerBean.class)
                 .addAsManifestResource(EmptyAsset.INSTANCE, "beans.xml")
                 .addAsWebInfResource(new StringAsset(
                                 "mp.context.ManagedExecutor.maxAsync=1\n" +

--- a/tck/src/main/java/org/eclipse/microprofile/context/tck/ProducerBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/context/tck/ProducerBean.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.microprofile.context.tck;
+
+import org.eclipse.microprofile.context.ManagedExecutor;
+import org.eclipse.microprofile.context.ThreadContext;
+import org.eclipse.microprofile.context.tck.contexts.buffer.Buffer;
+
+import javax.enterprise.context.ApplicationScoped;
+import javax.enterprise.inject.Disposes;
+import javax.enterprise.inject.Produces;
+import javax.inject.Named;
+
+/**
+ * Produces beans consumed by MpConfigBean in order to avoid circular dependencies
+ */
+@ApplicationScoped
+public class ProducerBean {
+
+    @Produces
+    @ApplicationScoped
+    @MPConfigBean.Max5Queue
+    protected ManagedExecutor createExecutor() {
+        // rely on MP Config for defaults of maxAsync=1, cleared=Remaining
+        return ManagedExecutor.builder()
+                .maxQueued(5)
+                .propagated()
+                .build();
+    }
+
+    public void shutdown(@Disposes @MPConfigBean.Max5Queue ManagedExecutor executor) {
+        executor.shutdown();
+    }
+
+    // None of the defaults from MP Config apply because the application explicitly specifies all values
+    @Produces
+    @ApplicationScoped
+    @Named("producedThreadContext")
+    protected ThreadContext bufferContext = ThreadContext.builder()
+            .propagated(Buffer.CONTEXT_NAME)
+            .unchanged()
+            .cleared(ThreadContext.ALL_REMAINING)
+            .build();
+}


### PR DESCRIPTION
This PR has no effect on the tests themselves, it just removes a circular bean dependency from the tests by moving the producers/disposer to a different bean that the one consuming them.

While circular dependencies are supported in CDI (to certain extent), they are not a nice practice, so I thought I'd improve that.