### PR TITLE
Rewrite TC/ME JTA test to use APIs while still allowing for m…

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -27,12 +27,4 @@
 
     <name>MicroProfile Context Propagation</name>
     <description>MicroProfile Context Propagation :: API</description>
-
-    <dependencies>
-        <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
-            <version>2.0</version>
-        </dependency>
-    </dependencies>
 </project>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -62,7 +62,6 @@
             <groupId>javax.enterprise</groupId>
             <artifactId>cdi-api</artifactId>
             <version>2.0</version>
-            <scope>provided</scope>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
…issing impls.

Fixes #178 

Rewrites test to eliminate reflections usage and instead uses standard APIs.