### PR TITLE
Switch version back to 1.1

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -18,12 +18,12 @@
     <parent>
         <groupId>org.eclipse.microprofile.context-propagation</groupId>
         <artifactId>microprofile-context-propagation-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>microprofile-context-propagation-api</artifactId>
     <packaging>jar</packaging>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
 
     <name>MicroProfile Context Propagation</name>
     <description>MicroProfile Context Propagation :: API</description>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <groupId>org.eclipse.microprofile.context-propagation</groupId>
     <artifactId>microprofile-context-propagation-parent</artifactId>
     <packaging>pom</packaging>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.1-SNAPSHOT</version>
 
     <name>MicroProfile Context Propagation</name>
     <description>Eclipse MicroProfile Context Propagation :: Parent POM</description>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.microprofile.context-propagation</groupId>
         <artifactId>microprofile-context-propagation-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.1-SNAPSHOT</version>
     </parent>
 
     <artifactId>microprofile-context-propagation-spec</artifactId>

--- a/spec/src/main/asciidoc/release_notes.asciidoc
+++ b/spec/src/main/asciidoc/release_notes.asciidoc
@@ -16,12 +16,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-[[release_notes_10]]
-== Release Notes for MicroProfile Context Propagation 1.0
+[[release_notes_1_1]]
+== Release Notes for MicroProfile Context Propagation 1.1
 
-http://download.eclipse.org/microprofile/microprofile-context-propagation-1.0/microprofile-context-propagation.pdf[MicroProfile Context Propagation Spec PDF]
-http://download.eclipse.org/microprofile/microprofile-context-propagation-1.0/microprofile-context-propagation.html[MicroProfile Context Propagation Spec HTML]
-http://download.eclipse.org/microprofile/microprofile-context-propagation-1.0/apidocs/[MicroProfile Context Propagation Spec Javadocs]
+http://download.eclipse.org/microprofile/microprofile-context-propagation-1.1/microprofile-context-propagation.pdf[MicroProfile Context Propagation Spec PDF]
+http://download.eclipse.org/microprofile/microprofile-context-propagation-1.1/microprofile-context-propagation.html[MicroProfile Context Propagation Spec HTML]
+http://download.eclipse.org/microprofile/microprofile-context-propagation-1.1/apidocs/[MicroProfile Context Propagation Spec Javadocs]
 
 Key features:
 
@@ -38,7 +38,7 @@ To get started, add this dependency to your project:
 <dependency>
     <groupId>org.eclipse.microprofile.context-propagation</groupId>
     <artifactId>microprofile-context-propagation-api</artifactId>
-    <version>1.0</version>
+    <version>1.1</version>
     <scope>provided</scope>
 </dependency>
 ----

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.microprofile.context-propagation</groupId>
         <artifactId>microprofile-context-propagation-parent</artifactId>
-        <version>1.0-SNAPSHOT</version>
+        <version>1.1-SNAPSHOT</version>
     </parent>
     <artifactId>microprofile-context-propagation-tck</artifactId>
     <name>microprofile-context-propagation-tck</name>


### PR DESCRIPTION
After the 1.0.1 micro-release is created for the TCK updates, this pull will undo the revert (#181) of #174 .  The end result will be putting us back at 1.1 to resume progress of the next spec version.