### PR TITLE
Contextualise CF tck

### DIFF
--- a/tck/src/main/java/org/eclipse/microprofile/context/tck/TckThread.java
+++ b/tck/src/main/java/org/eclipse/microprofile/context/tck/TckThread.java
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2018,2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.microprofile.context.tck;
+
+public class TckThread extends Thread {
+
+    public TckThread(Runnable r) {
+        super(r);
+    }
+
+}

--- a/tck/src/main/java/org/eclipse/microprofile/context/tck/TckThreadFactory.java
+++ b/tck/src/main/java/org/eclipse/microprofile/context/tck/TckThreadFactory.java
@@ -1,0 +1,30 @@
+/*
+ * Copyright (c) 2018,2019 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * You may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.eclipse.microprofile.context.tck;
+
+import java.util.concurrent.ThreadFactory;
+
+public class TckThreadFactory implements ThreadFactory {
+
+    @Override
+    public Thread newThread(Runnable r) {
+        return new TckThread(r);
+    }
+
+}

--- a/tck/src/main/java/org/eclipse/microprofile/context/tck/ThreadContextTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/context/tck/ThreadContextTest.java
@@ -946,14 +946,6 @@ public class ThreadContextTest extends Arquillian {
             // guarantees about context propagation
             CompletableFuture<Integer> unmanagedStage5 = unmanagedStage1.thenApply(i -> i / 2);
 
-            try {
-                CompletableFuture<Integer> stage6 = stage4.thenApplyAsync(i -> i / 5);
-                Assert.fail("Should not be able to create async completion stage because withContextCapture provides no executor. " + stage6);
-            }
-            catch (UnsupportedOperationException x) {
-                // test passes, CompletableFutures from withContextCapture are not backed by an executor
-            }
-
             Label.set("withContextCapture-CompletableFuture-test-label-E");
 
             unmanagedStage1.complete(1010);
@@ -1064,14 +1056,6 @@ public class ThreadContextTest extends Arquillian {
 
                 return i - 2345;
             }, labelContextExecutor); // supplied executor runs the action, but does not determine context propagation
-
-            try {
-                CompletionStage<Void> stage5 = stage4.thenAcceptAsync(i -> System.out.println("This should not ever run."));
-                Assert.fail("Should not be able to create async completion stage because withContextCapture provides no executor. " + stage5);
-            }
-            catch (UnsupportedOperationException x) {
-                // test passes, CompletableFutures from withContextCapture are not backed by an executor
-            }
 
             Buffer.set(new StringBuffer("withContextCapture-CompletionStage-test-buffer-E"));
 


### PR DESCRIPTION
This is the TCK part of #173 whose code PR was merged.

I've added tests for the following things:

- `ManagedExecutor.copy(CF/CS)` will propagate contexts
- `ManagedExecutor.getThreadContext()` will return an instance with the same propagation settings as the `ManagedExecutor`
- `ManagedExecutor.newIncompleteFuture()` (hoping all other methods behave the same, I didn't think it was worth testing them all, should I?) will respect the new `ContextManager.Builder.withDefaultExecutorService()`
- `ThreadContext.withContextPropagation(CF/CS)` will respect the new `ContextManager.Builder.withDefaultExecutorService()`, and ban `Async` methods with no executor if not set, and allow them if set

Did I forget something?