### PR TITLE
 revert to 1.2-SNAPSHOT to undo changes made by failed Jenkins build

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -18,12 +18,12 @@
     <parent>
         <groupId>org.eclipse.microprofile.context-propagation</groupId>
         <artifactId>microprofile-context-propagation-parent</artifactId>
-        <version>1.2-RC1</version>
+        <version>1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>microprofile-context-propagation-api</artifactId>
     <packaging>jar</packaging>
-    <version>1.2-RC1</version>
+    <version>1.2-SNAPSHOT</version>
 
     <name>MicroProfile Context Propagation</name>
     <description>MicroProfile Context Propagation :: API</description>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <groupId>org.eclipse.microprofile.context-propagation</groupId>
     <artifactId>microprofile-context-propagation-parent</artifactId>
     <packaging>pom</packaging>
-    <version>1.2-RC1</version>
+    <version>1.2-SNAPSHOT</version>
 
     <name>MicroProfile Context Propagation</name>
     <description>Eclipse MicroProfile Context Propagation :: Parent POM</description>
@@ -72,7 +72,7 @@
         <connection>scm:git:https://github.com/eclipse/microprofile-context-propagation.git</connection>
         <developerConnection>scm:git:git@github.com:eclipse/microprofile-context-propagation.git</developerConnection>
         <url>https://github.com/eclipse/microprofile-context-propagation</url>
-        <tag>1.2-RC1</tag>
+        <tag>HEAD</tag>
     </scm>
 
     <distributionManagement>

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.microprofile.context-propagation</groupId>
         <artifactId>microprofile-context-propagation-parent</artifactId>
-        <version>1.2-RC1</version>
+        <version>1.2-SNAPSHOT</version>
     </parent>
 
     <artifactId>microprofile-context-propagation-spec</artifactId>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.microprofile.context-propagation</groupId>
         <artifactId>microprofile-context-propagation-parent</artifactId>
-        <version>1.2-RC1</version>
+        <version>1.2-SNAPSHOT</version>
     </parent>
     <artifactId>microprofile-context-propagation-tck</artifactId>
     <name>microprofile-context-propagation-tck</name>


### PR DESCRIPTION
A Jenkins build for 1.2-RC1 failed halfway through and left partial changes in place. This pull reverts them.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>