### PR TITLE
Issue #210 update TCK and doc for Jakarta EE 9 packages

### DIFF
--- a/mp_checkstyle_rules.xml
+++ b/mp_checkstyle_rules.xml
@@ -51,7 +51,7 @@
         </module>
         <module name="AvoidStarImport">
             <property name="excludes"
-                      value="java.io,java.net,java.util,javax.enterprise.inject.spi,javax.enterprise.context,org.testng.Assert"/>
+                      value="java.io,java.net,java.util,jakarta.enterprise.inject.spi,jakarta.enterprise.context,org.testng.Assert"/>
         </module>
         <module name="IllegalImport"/>
         <module name="RedundantImport"/>

--- a/spec/src/main/asciidoc/builders.asciidoc
+++ b/spec/src/main/asciidoc/builders.asciidoc
@@ -1,5 +1,5 @@
 //
-// Copyright (c) 2018,2019 Contributors to the Eclipse Foundation
+// Copyright (c) 2018,2021 Contributors to the Eclipse Foundation
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -25,10 +25,10 @@ The MicroProfile Context Propagation spec defines a fluent builder API to progra
 ----
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.CompletableFuture;
-import javax.servlet.ServletConfig;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.eclipse.microprofile.context.ManagedExecutor;
 import org.eclipse.microprofile.context.ThreadContext;
 
@@ -67,10 +67,10 @@ efficiently free up resources.
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Function;
 import java.util.function.Supplier;
-import javax.servlet.ServletConfig;
-import javax.servlet.http.HttpServlet;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletConfig;
+import jakarta.servlet.http.HttpServlet;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.eclipse.microprofile.context.ThreadContext;
 
 public class ExampleServlet extends HttpServlet {

--- a/spec/src/main/asciidoc/cdi.asciidoc
+++ b/spec/src/main/asciidoc/cdi.asciidoc
@@ -28,7 +28,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import javax.inject.Qualifier;
+import jakarta.inject.Qualifier;
 
 @Qualifier
 @Retention(RetentionPolicy.RUNTIME)
@@ -41,8 +41,8 @@ Example producer and disposer,
 ----
 import org.eclipse.microprofile.context.ManagedExecutor;
 import org.eclipse.microprofile.context.ThreadContext;
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Produces;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
 
 @ApplicationScoped
 public class MyFirstBean {
@@ -61,8 +61,8 @@ Example injection point,
 [source, java]
 ----
 import org.eclipse.microprofile.context.ManagedExecutor;
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 
 @ApplicationScoped
 public class MySecondBean {
@@ -81,7 +81,7 @@ import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
-import javax.inject.Qualifier;
+import jakarta.inject.Qualifier;
 
 @Qualifier
 @Retention(RetentionPolicy.RUNTIME)
@@ -94,8 +94,8 @@ Example producer method,
 [source, java]
 ----
 import org.eclipse.microprofile.context.ThreadContext;
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Produces;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
 
 @ApplicationScoped
 public class MyFirstBean {
@@ -114,8 +114,8 @@ Example injection point,
 [source, java]
 ----
 import org.eclipse.microprofile.context.ThreadContext;
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
 ...
 
 @ApplicationScoped

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -61,7 +61,7 @@
         <dependency>
             <groupId>jakarta.enterprise</groupId>
             <artifactId>jakarta.enterprise.cdi-api</artifactId>
-            <version>2.0.2</version>
+            <version>3.0.0</version>
             <scope>provided</scope>
             <exclusions>
                 <exclusion>
@@ -74,7 +74,7 @@
         <dependency>
             <groupId>jakarta.transaction</groupId>
             <artifactId>jakarta.transaction-api</artifactId>
-            <version>1.3.3</version>
+            <version>2.0.0</version>
             <scope>provided</scope>
         </dependency>
 

--- a/tck/src/main/java/org/eclipse/microprofile/context/tck/MPConfigBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/context/tck/MPConfigBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019,2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -25,10 +25,10 @@ import java.lang.annotation.Target;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-import javax.inject.Named;
-import javax.inject.Qualifier;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
+import jakarta.inject.Qualifier;
 
 import org.eclipse.microprofile.context.tck.contexts.buffer.Buffer;
 import org.eclipse.microprofile.context.tck.contexts.label.Label;

--- a/tck/src/main/java/org/eclipse/microprofile/context/tck/MPConfigTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/context/tck/MPConfigTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019,2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019,2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -28,8 +28,8 @@ import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.TimeUnit;
 
-import javax.inject.Inject;
-import javax.inject.Named;
+import jakarta.inject.Inject;
+import jakarta.inject.Named;
 
 import org.eclipse.microprofile.context.tck.MPConfigBean.Max5Queue;
 import org.eclipse.microprofile.context.tck.contexts.buffer.Buffer;

--- a/tck/src/main/java/org/eclipse/microprofile/context/tck/ManagedExecutorTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/context/tck/ManagedExecutorTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018,2020 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018,2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -48,12 +48,13 @@ import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import javax.enterprise.inject.Instance;
-import javax.enterprise.inject.spi.CDI;
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.spi.CDI;
+import jakarta.transaction.Status;
+import jakarta.transaction.UserTransaction;
+
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
-import javax.transaction.Status;
-import javax.transaction.UserTransaction;
 
 import org.eclipse.microprofile.context.tck.contexts.buffer.Buffer;
 import org.eclipse.microprofile.context.tck.contexts.buffer.spi.BufferContextProvider;

--- a/tck/src/main/java/org/eclipse/microprofile/context/tck/ProducerBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/context/tck/ProducerBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019,2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -22,10 +22,10 @@ import org.eclipse.microprofile.context.ManagedExecutor;
 import org.eclipse.microprofile.context.ThreadContext;
 import org.eclipse.microprofile.context.tck.contexts.buffer.Buffer;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Disposes;
-import javax.enterprise.inject.Produces;
-import javax.inject.Named;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Disposes;
+import jakarta.enterprise.inject.Produces;
+import jakarta.inject.Named;
 
 /**
  * Produces beans consumed by MpConfigBean in order to avoid circular dependencies

--- a/tck/src/main/java/org/eclipse/microprofile/context/tck/ThreadContextTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/context/tck/ThreadContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2018,2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2018,2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -35,12 +35,13 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Supplier;
 
-import javax.enterprise.inject.Instance;
-import javax.enterprise.inject.spi.CDI;
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.spi.CDI;
+import jakarta.transaction.Status;
+import jakarta.transaction.UserTransaction;
+
 import javax.naming.InitialContext;
 import javax.naming.NamingException;
-import javax.transaction.Status;
-import javax.transaction.UserTransaction;
 
 import org.eclipse.microprofile.context.tck.contexts.buffer.Buffer;
 import org.eclipse.microprofile.context.tck.contexts.buffer.spi.BufferContextProvider;

--- a/tck/src/main/java/org/eclipse/microprofile/context/tck/cdi/BasicCDITest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/context/tck/cdi/BasicCDITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019,2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -20,7 +20,7 @@ package org.eclipse.microprofile.context.tck.cdi;
 
 import java.lang.reflect.Method;
 
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 
 import org.eclipse.microprofile.context.tck.contexts.buffer.spi.BufferContextProvider;
 import org.eclipse.microprofile.context.tck.contexts.label.spi.LabelContextProvider;

--- a/tck/src/main/java/org/eclipse/microprofile/context/tck/cdi/CDIBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/context/tck/cdi/CDIBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019,2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -28,9 +28,9 @@ import java.lang.annotation.Target;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-import javax.inject.Qualifier;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.inject.Qualifier;
 
 import org.eclipse.microprofile.context.tck.contexts.buffer.Buffer;
 import org.eclipse.microprofile.context.tck.contexts.label.Label;

--- a/tck/src/main/java/org/eclipse/microprofile/context/tck/cdi/CDIContextTest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/context/tck/cdi/CDIContextTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019,2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -26,13 +26,13 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 
-import javax.enterprise.context.ContextNotActiveException;
-import javax.enterprise.context.ConversationScoped;
-import javax.enterprise.context.RequestScoped;
-import javax.enterprise.context.SessionScoped;
-import javax.enterprise.inject.Instance;
-import javax.enterprise.inject.spi.BeanManager;
-import javax.inject.Inject;
+import jakarta.enterprise.context.ContextNotActiveException;
+import jakarta.enterprise.context.ConversationScoped;
+import jakarta.enterprise.context.RequestScoped;
+import jakarta.enterprise.context.SessionScoped;
+import jakarta.enterprise.inject.Instance;
+import jakarta.enterprise.inject.spi.BeanManager;
+import jakarta.inject.Inject;
 
 import org.eclipse.microprofile.context.ManagedExecutor;
 import org.eclipse.microprofile.context.ThreadContext;

--- a/tck/src/main/java/org/eclipse/microprofile/context/tck/cdi/CdiBeanProducer.java
+++ b/tck/src/main/java/org/eclipse/microprofile/context/tck/cdi/CdiBeanProducer.java
@@ -23,8 +23,8 @@ import org.eclipse.microprofile.context.ThreadContext;
 import org.eclipse.microprofile.context.tck.contexts.buffer.Buffer;
 import org.eclipse.microprofile.context.tck.contexts.label.Label;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.enterprise.inject.Produces;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.enterprise.inject.Produces;
 import java.util.concurrent.Executor;
 
 import static org.eclipse.microprofile.context.tck.contexts.priority.spi.ThreadPriorityContextProvider.THREAD_PRIORITY;

--- a/tck/src/main/java/org/eclipse/microprofile/context/tck/cdi/ConversationScopedBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/context/tck/cdi/ConversationScopedBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019,2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -20,7 +20,7 @@ package org.eclipse.microprofile.context.tck.cdi;
 
 import java.io.Serializable;
 
-import javax.enterprise.context.ConversationScoped;
+import jakarta.enterprise.context.ConversationScoped;
 
 @ConversationScoped
 public class ConversationScopedBean extends AbstractBean implements Serializable {

--- a/tck/src/main/java/org/eclipse/microprofile/context/tck/cdi/JTACDITest.java
+++ b/tck/src/main/java/org/eclipse/microprofile/context/tck/cdi/JTACDITest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019,2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -31,14 +31,14 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Ignore;
 import org.testng.annotations.Test;
 
-import javax.enterprise.inject.spi.CDI;
-import javax.inject.Inject;
-import javax.transaction.NotSupportedException;
-import javax.transaction.Status;
-import javax.transaction.SystemException;
-import javax.transaction.TransactionManager;
-import javax.transaction.Transactional;
-import javax.transaction.UserTransaction;
+import jakarta.enterprise.inject.spi.CDI;
+import jakarta.inject.Inject;
+import jakarta.transaction.NotSupportedException;
+import jakarta.transaction.Status;
+import jakarta.transaction.SystemException;
+import jakarta.transaction.TransactionManager;
+import jakarta.transaction.Transactional;
+import jakarta.transaction.UserTransaction;
 import java.lang.reflect.Method;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletableFuture;

--- a/tck/src/main/java/org/eclipse/microprofile/context/tck/cdi/RequestScopedBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/context/tck/cdi/RequestScopedBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019,2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -18,7 +18,7 @@
  */
 package org.eclipse.microprofile.context.tck.cdi;
 
-import javax.enterprise.context.RequestScoped;
+import jakarta.enterprise.context.RequestScoped;
 
 @RequestScoped
 public class RequestScopedBean extends AbstractBean {}

--- a/tck/src/main/java/org/eclipse/microprofile/context/tck/cdi/SessionScopedBean.java
+++ b/tck/src/main/java/org/eclipse/microprofile/context/tck/cdi/SessionScopedBean.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019,2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -20,7 +20,7 @@ package org.eclipse.microprofile.context.tck.cdi;
 
 import java.io.Serializable;
 
-import javax.enterprise.context.SessionScoped;
+import jakarta.enterprise.context.SessionScoped;
 
 @SessionScoped
 public class SessionScopedBean extends AbstractBean implements Serializable {

--- a/tck/src/main/java/org/eclipse/microprofile/context/tck/cdi/TransactionalBeanImpl.java
+++ b/tck/src/main/java/org/eclipse/microprofile/context/tck/cdi/TransactionalBeanImpl.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019,2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -18,7 +18,7 @@
  */
 package org.eclipse.microprofile.context.tck.cdi;
 
-import javax.transaction.TransactionScoped;
+import jakarta.transaction.TransactionScoped;
 import java.io.Serializable;
 import java.util.concurrent.atomic.AtomicInteger;
 

--- a/tck/src/main/java/org/eclipse/microprofile/context/tck/cdi/TransactionalService.java
+++ b/tck/src/main/java/org/eclipse/microprofile/context/tck/cdi/TransactionalService.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2019 Contributors to the Eclipse Foundation
+ * Copyright (c) 2019,2021 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -20,9 +20,9 @@ package org.eclipse.microprofile.context.tck.cdi;
 
 import org.eclipse.microprofile.context.ManagedExecutor;
 
-import javax.enterprise.context.ApplicationScoped;
-import javax.inject.Inject;
-import javax.transaction.Transactional;
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionException;
 


### PR DESCRIPTION
Updates the TCK and a couple of code examples in the documentation to use jakarta packages.
This is hopefully all we need to change with respect to code for the Jakarta EE 9 alignment effort.
See #210 for more detail.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>