### PR TITLE
gpg plugin was broken by merge with common pom

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -425,11 +425,6 @@
                     <artifactId>eclipse-jarsigner-plugin</artifactId>
                     <version>1.1.4</version>
                 </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-gpg-plugin</artifactId>
-                    <version>1.6</version>
-                </plugin>
             </plugins>
         </pluginManagement>
 
@@ -789,6 +784,12 @@
                                 <goals>
                                     <goal>sign</goal>
                                 </goals>
+                                <configuration>
+                                    <gpgArguments>
+                                        <arg>--pinentry-mode</arg>
+                                        <arg>loopback</arg>
+                                    </gpgArguments>
+                                </configuration>
                             </execution>
                         </executions>
                     </plugin>


### PR DESCRIPTION
Unfortunately, the merge with the common pom to fix the license issue had the side-effect of breaking the gpg plugin when run in jenkins.  It looks like we ended up with duplicate entries for it, one lacking some configuration.  I'm attempting to correct that under this pull.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>