### PR TITLE
Revert to 1.3 again and set to Final

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -18,12 +18,12 @@
     <parent>
         <groupId>org.eclipse.microprofile.context-propagation</groupId>
         <artifactId>microprofile-context-propagation-parent</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>microprofile-context-propagation-api</artifactId>
     <packaging>jar</packaging>
-    <version>1.4-SNAPSHOT</version>
+    <version>1.3-SNAPSHOT</version>
 
     <name>MicroProfile Context Propagation</name>
     <description>MicroProfile Context Propagation :: API</description>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
     <groupId>org.eclipse.microprofile.context-propagation</groupId>
     <artifactId>microprofile-context-propagation-parent</artifactId>
     <packaging>pom</packaging>
-    <version>1.4-SNAPSHOT</version>
+    <version>1.3-SNAPSHOT</version>
 
     <name>MicroProfile Context Propagation</name>
     <description>Eclipse MicroProfile Context Propagation :: Parent POM</description>
@@ -78,7 +78,7 @@
 
         <!-- Release -->
         <release.arguments />
-        <release.revision>Draft</release.revision>
+        <release.revision>Final</release.revision>
 
         <checkstyle.methodNameFormat>^_?[a-z][a-zA-Z0-9]*$</checkstyle.methodNameFormat>
         <!-- whether autorelease maven central staging repositories - default true to allow review and manually release repositories -->
@@ -86,7 +86,7 @@
         <!-- keeping closed repos with failure - default is false because the errors are visible in the maven output, but true will leave the repo open for investigation in Sonatype Nexus -->
         <keepStagingReposOnFailure>false</keepStagingReposOnFailure>
 
-        <revremark>Draft</revremark>
+        <revremark>${release.revision}</revremark>
         <inceptionYear>2018</inceptionYear>
     </properties>
 

--- a/spec/pom.xml
+++ b/spec/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>org.eclipse.microprofile.context-propagation</groupId>
         <artifactId>microprofile-context-propagation-parent</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.3-SNAPSHOT</version>
     </parent>
 
     <artifactId>microprofile-context-propagation-spec</artifactId>

--- a/tck/pom.xml
+++ b/tck/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.microprofile.context-propagation</groupId>
         <artifactId>microprofile-context-propagation-parent</artifactId>
-        <version>1.4-SNAPSHOT</version>
+        <version>1.3-SNAPSHOT</version>
     </parent>
     <artifactId>microprofile-context-propagation-tck</artifactId>
     <name>microprofile-context-propagation-tck</name>


### PR DESCRIPTION
For some reason the jenkins build didn't update from Draft to Final, and so some of the artifacts were labeled Draft.  We can work around this by temporarily hard coding the pom to Final.

Signed-off-by: Nathan Rauh <nathan.rauh@us.ibm.com>